### PR TITLE
git_ignore added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,70 @@
+# Django specific
+*.pyc
+*.pyo
+*.pyd
+__pycache__/
+db.sqlite3
+/media
+/staticfiles
+/static_root/
+/.env
+.env.*
+
+# Django migrations
+**/migrations/
+!**/migrations/__init__.py
+
+# Python
+.Python
+env/
+venv/
+ENV/
+venv.bak/
+*.bak
+*.swp
+
+# VSCode / IDE files
+.vscode/
+.idea/
+*.sublime-project
+*.sublime-workspace
+
+# Docker
+*.log
+docker-compose.override.yml
+docker-compose.dev.yml
+docker-compose.test.yml
+.docker/
+build/
+tmp/
+
+# MySQL
+*.sql
+*.dump
+*.mysql
+
+# OS generated
+.DS_Store
+Thumbs.db
+
+# Coverage reports
+htmlcov/
+.coverage
+.tox/
+.pytest_cache/
+
+# Pipenv
+Pipfile.lock
+
+# Testing
+.coverage
+.junit/
+
+# Node (for React/JS frontend)
+node_modules/
+npm-debug.log
+yarn-error.log
+
+# Other
+*.backup
+*.bak


### PR DESCRIPTION
## Summary

This pull request adds a `.gitignore` file tailored for a Django REST Framework backend project using Docker and MySQL. The `.gitignore` ensures that unnecessary or sensitive files (e.g., compiled Python files, environment configs, Docker artifacts, database dumps) are not tracked by Git.

## Changes Introduced

-   Added `.gitignore` file.
    
-   Ignored:
    
    -   Python cache files (`*.pyc`, `__pycache__/`)
        
    -   Django migration files (except `__init__.py`)
        
    -   Local static/media files
        
    -   Local environment files (`.env`)
        
    -   Docker build artifacts and override configs
        
    -   MySQL dump files (`*.sql`, `*.dump`)
        
    -   OS and IDE-specific files (`.DS_Store`, `.vscode/`, `.idea/`)
        
    -   NodeJS artifacts (`node_modules/`) in case of a frontend extension later.