### PR TITLE
Add swagger for our project

### DIFF
--- a/backend/fithub/fithub/settings.py
+++ b/backend/fithub/fithub/settings.py
@@ -19,7 +19,6 @@ pymysql.install_as_MySQLdb()
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
-print(f"BASE_DIR: {BASE_DIR}")
 
 # Load environment variables from .env file
 load_dotenv(os.path.join(BASE_DIR, '.env'))
@@ -44,9 +43,10 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'rest_framework',
-    'rest_framework.authtoken',
-    'api',
+    'rest_framework', # Django REST framework
+    'rest_framework.authtoken', # Token authentication
+    'drf_yasg', # Swagger and ReDoc
+    'api',      # Our main api
 ]
 
 MIDDLEWARE = [
@@ -68,6 +68,7 @@ TEMPLATES = [
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
+                'django.template.context_processors.debug',
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',

--- a/backend/fithub/fithub/urls.py
+++ b/backend/fithub/fithub/urls.py
@@ -17,11 +17,28 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path, include
 from api.views import index  
+from rest_framework import permissions
+from drf_yasg.views import get_schema_view
+from drf_yasg import openapi
+
+schema_view = get_schema_view(
+    openapi.Info(
+        title="Fithub API",
+        default_version='v1',
+        description="API documentation for Fithub project",
+        terms_of_service="https://www.google.com/policies/terms/",
+        contact=openapi.Contact(email="celilozkan76@gmail.com"),
+        license=openapi.License(name="BSD License"),
+    ),
+    public=True,
+    permission_classes=[permissions.AllowAny],
+)
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    # include the api urls
     path('api/', include('api.urls')),
     path('', index, name='index_page'),  # Map the root URL to the index page view
+    path('swagger/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
+    path('redoc/', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
 ]
 

--- a/backend/fithub/manage.py
+++ b/backend/fithub/manage.py
@@ -17,6 +17,5 @@ def main():
         ) from exc
     execute_from_command_line(sys.argv)
 
-
 if __name__ == '__main__':
     main()

--- a/backend/fithub/requirements.txt
+++ b/backend/fithub/requirements.txt
@@ -1,6 +1,7 @@
 Django==5.2
 djangorestframework==3.15.2
 mysqlclient==2.1.0       # For MySQL database connection (sometimes fails)
-PyMySQL==1.1.1  # Needed for MySQL connection if mysqlclient won't work
+PyMySQL==1.1.1           # For MySQL connection if mysqlclient won't work
 psycopg2-binary>=2.9
-python-dotenv==1.0.1     # Needed to read .env file
+python-dotenv==1.0.1     # To read .env file
+drf-yasg>=1.21.7         # For swagger documentation


### PR DESCRIPTION
## Related Issue: https://github.com/bounswe/bounswe2025group6/issues/146

## Changes Made:
- Implemented Swagger endpoints for our project

Now we can safely check <development_link>/swagger/ ( http://127.0.0.1:8000/swagger/  for local development) and when we implement some endpoints we will be able to easily send requests using swagger.