### PR TITLE
Implement Logout API Endpoint

### DIFF
--- a/backend/fithub/api/urls.py
+++ b/backend/fithub/api/urls.py
@@ -1,10 +1,11 @@
 # myproject/urls.py
 from django.urls import path 
 from . import views
-from .views import register_user, verify_email, login_view
+from .views import register_user, verify_email, login_view, logout_view
 
 urlpatterns = [
     path('register/', views.register_user, name='register_user'),
     path('verify-email/<uidb64>/<token>/', verify_email, name='email-verify'),
     path('login/', login_view.as_view(), name='login_view'),
+    path('logout/', logout_view.as_view(), name='logout_view'),
 ]

--- a/backend/fithub/api/views.py
+++ b/backend/fithub/api/views.py
@@ -18,6 +18,7 @@ from drf_yasg import openapi
 from rest_framework.response import Response
 from rest_framework import status
 from rest_framework.authtoken.models import Token
+from rest_framework.permissions import IsAuthenticated
 
 from .serializers import UserRegistrationSerializer, LoginSerializer
 
@@ -32,6 +33,7 @@ def index(request):
     method='post',
     request_body=UserRegistrationSerializer(),
 )
+
 @api_view(['POST'])
 def register_user(request):
     serializer = UserRegistrationSerializer(data=request.data)
@@ -104,3 +106,16 @@ class login_view(APIView):
                 'usertype': user.usertype,
             })
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+class logout_view(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request):
+        try:
+            # Get the token associated with the current user
+            token = Token.objects.get(user=request.user)
+            token.delete()  # Delete the token to log out the user
+            return Response({"detail": "Successfully logged out."}, status=status.HTTP_200_OK)
+        except Token.DoesNotExist:
+            return Response({"detail": "No token found."}, status=status.HTTP_400_BAD_REQUEST)
+

--- a/backend/fithub/api/views.py
+++ b/backend/fithub/api/views.py
@@ -94,6 +94,14 @@ send_mail(
 )
 
 class login_view(APIView):
+    @swagger_auto_schema(
+        request_body=LoginSerializer(),  # Specify the serializer for login
+        responses={
+            200: 'Successful login response with token',
+            400: 'Bad request',
+            401: 'Invalid credentials'
+        }
+    )
     def post(self, request):
         serializer = LoginSerializer(data=request.data)
         if serializer.is_valid():
@@ -109,7 +117,24 @@ class login_view(APIView):
 
 class logout_view(APIView):
     permission_classes = [IsAuthenticated]
-
+    @swagger_auto_schema(
+        operation_description="Logs out the user by deleting the authentication token.",
+        produces=["application/json"],
+        manual_parameters=[
+            openapi.Parameter(
+                'Authorization',
+                openapi.IN_HEADER,
+                description="Token-based authorization. Format: `Token <your_token>`",
+                type=openapi.TYPE_STRING,
+                required=True
+            )
+        ],
+        responses={
+            200: openapi.Response(description="Logout successful"),
+            400: openapi.Response(description="No token found"),
+            401: openapi.Response(description="User not authenticated"),
+        }
+    )
     def post(self, request):
         try:
             # Get the token associated with the current user

--- a/backend/fithub/api_documentations/logout.md
+++ b/backend/fithub/api_documentations/logout.md
@@ -1,0 +1,75 @@
+
+### **User logout**
+
+  
+
+**POST**  `/api/logout/`
+
+  
+
+-  **Description**: This endpoint logs out the currently authenticated user by deleting their authentication token. The user must be logged in using token-based authentication.
+
+#### Request Headers:
+
+  
+
+    Authorization: Token <your_token>
+
+  
+
+#### Request Body Example:
+
+  
+
+No request body is required.
+
+  
+
+#### Fields:
+
+No request body is required.
+
+  
+
+#### Response:
+
+  
+
+-  **Success**:
+
+- Status: `200 OK`
+
+  
+
+- Response body:
+
+  
+
+    {
+    
+    "detail": "Successfully logged out."
+    
+    }
+
+  
+
+-  **Error**:
+
+- Status: `400 Bad Request`
+
+- Possible Message:
+
+    {
+        "detail": "No token found."
+    }
+
+
+
+- Status: `400 Bad Request`
+
+- Possible Message:
+
+    {
+        "detail": "Authentication credentials were not provided."
+    }
+

--- a/backend/fithub/misc/test.rest
+++ b/backend/fithub/misc/test.rest
@@ -22,4 +22,4 @@ Content-Type: application/json
 ###
 
 POST http://127.0.0.1:8000/api/logout/
-Authorization: Token a18355f86523592f365f8e0fff52f21f17c73cbb
+Authorization: Token a9d0cb508b5af8cb61b963decb754081c00b1b7e

--- a/backend/fithub/misc/test.rest
+++ b/backend/fithub/misc/test.rest
@@ -16,7 +16,10 @@ POST http://127.0.0.1:8000/api/login/
 Content-Type: application/json
 
 {
-  "email": "dietitian.john154@example.com",
-  "password": "secureDietitianPassword123"
+  "email": "savasciogluozgur@gmail.com",
+  "password": "123"
 }
+###
 
+POST http://127.0.0.1:8000/api/logout/
+Authorization: Token a18355f86523592f365f8e0fff52f21f17c73cbb

--- a/backend/fithub/misc/test.rest
+++ b/backend/fithub/misc/test.rest
@@ -22,4 +22,4 @@ Content-Type: application/json
 ###
 
 POST http://127.0.0.1:8000/api/logout/
-Authorization: Token a9d0cb508b5af8cb61b963decb754081c00b1b7e
+Authorization: Token d2a5f9c71b45d88ed04b8ce9d2ceec2378b47c25


### PR DESCRIPTION

**Summary:**  
This PR implements the `/api/logout/` endpoint which allows authenticated users to log out by deleting their authentication token. The endpoint uses token-based authentication and requires a valid `Authorization: Token <token>` header.

**Key Features:**

-   Implemented `logout_view` using Django REST Framework's `APIView`
    
-   Applied `IsAuthenticated` permission to restrict access
    
-   Deletes the user’s token upon request, effectively logging them out
    
-   Returns appropriate responses for success, missing token, or unauthenticated access
    
-   Added README documentation for frontend integration
    

**Testing:**

-   Manually tested with:
    
    -   Valid token → receives `200 OK` and "Successfully logged out" message
        
    -   No token → receives `401 Unauthorized`
        
    -   Already-logged-out user → receives `400 Bad Request`
    -   Invalid token → receives `400 Bad Request`
