### PR TITLE
 Implement Two Versions of Password Reset: Email Link & 6-Digit Code

### DIFF
--- a/backend/fithub/api/models.py
+++ b/backend/fithub/api/models.py
@@ -1,6 +1,7 @@
 from django.db import models
 from django.contrib.auth.models import AbstractUser
 from django.utils import timezone
+from datetime import timedelta
 from django.utils.timezone import now
 
 class TimestampedModel(models.Model):
@@ -40,4 +41,13 @@ class RegisteredUser(AbstractUser, TimestampedModel):
 class Dietitian(TimestampedModel, models.Model):
     registered_user = models.OneToOneField(RegisteredUser, on_delete=models.CASCADE, related_name='dietitian')
     certification_url = models.URLField()
+
+class PasswordResetCode(models.Model):
+    email = models.EmailField()
+    code = models.CharField(max_length=6)
+    created_at = models.DateTimeField(auto_now_add=True)
+    is_used = models.BooleanField(default=False)
+
+    def is_expired(self):
+        return self.created_at + timedelta(minutes=10) < timezone.now()
 

--- a/backend/fithub/api/urls.py
+++ b/backend/fithub/api/urls.py
@@ -1,11 +1,13 @@
 # myproject/urls.py
 from django.urls import path 
 from . import views
-from .views import register_user, verify_email, login_view, logout_view
+from .views import register_user, forgot_password, password_reset, verify_email, login_view, logout_view
 
 urlpatterns = [
     path('register/', views.register_user, name='register_user'),
     path('verify-email/<uidb64>/<token>/', verify_email, name='email-verify'),
+    path('forgot-password/', views.forgot_password, name='forgot-password'),
+    path('password-reset/<uidb64>/<token>/', views.password_reset, name='password-reset'),
     path('login/', login_view.as_view(), name='login_view'),
     path('logout/', logout_view.as_view(), name='logout_view'),
 ]

--- a/backend/fithub/api/urls.py
+++ b/backend/fithub/api/urls.py
@@ -1,13 +1,15 @@
 # myproject/urls.py
 from django.urls import path 
 from . import views
-from .views import register_user, forgot_password, password_reset, verify_email, login_view, logout_view
+from .views import register_user, forgot_password, password_reset, verify_email, login_view, logout_view, RequestResetCodeView, VerifyResetCodeView
 
 urlpatterns = [
     path('register/', views.register_user, name='register_user'),
     path('verify-email/<uidb64>/<token>/', verify_email, name='email-verify'),
     path('forgot-password/', views.forgot_password, name='forgot-password'),
     path('password-reset/<uidb64>/<token>/', views.password_reset, name='password-reset'),
+    path('request-password-reset-code/', RequestResetCodeView.as_view(), name='request-password-reset-code'),
+    path('verify-reset-code/', VerifyResetCodeView.as_view(), name='verify-reset-code'),
     path('login/', login_view.as_view(), name='login_view'),
     path('logout/', logout_view.as_view(), name='logout_view'),
 ]

--- a/backend/fithub/api/views.py
+++ b/backend/fithub/api/views.py
@@ -20,8 +20,7 @@ from rest_framework import status
 from rest_framework.authtoken.models import Token
 from rest_framework.permissions import IsAuthenticated
 
-from .serializers import UserRegistrationSerializer, LoginSerializer
-
+from .serializers import UserRegistrationSerializer, LoginSerializer, RequestPasswordResetCodeSerializer, VerifyPasswordResetCodeSerializer
 
 User = get_user_model()
 
@@ -160,7 +159,34 @@ def password_reset(request, uidb64, token):
     
     return Response({"error": "Invalid token."}, status=status.HTTP_400_BAD_REQUEST)
 
+class RequestResetCodeView(APIView):
+    @swagger_auto_schema(
+        operation_description="Request a 6-digit password reset code to be sent to your email.",
+        request_body=RequestPasswordResetCodeSerializer,
+        responses={200: "Code sent", 400: "Validation error"}
+    )
+    def post(self, request):
+        serializer = RequestPasswordResetCodeSerializer(data=request.data)
+        if serializer.is_valid():
+            serializer.save()
+            
+            return Response({"detail": "A reset code has been sent to your email."})
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
+
+class VerifyResetCodeView(APIView):
+    @swagger_auto_schema(
+        operation_description="Verify 6-digit code and reset password.",
+        request_body=VerifyPasswordResetCodeSerializer,
+        responses={200: "Password reset", 400: "Validation error"}
+    )
+    def post(self, request):
+        serializer = VerifyPasswordResetCodeSerializer(data=request.data)
+        if serializer.is_valid():
+            serializer.save()
+            return Response({"detail": "Password has been successfully reset."})
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+    
 class login_view(APIView):
     @swagger_auto_schema(
         request_body=LoginSerializer(),  # Specify the serializer for login

--- a/backend/fithub/api/views.py
+++ b/backend/fithub/api/views.py
@@ -93,6 +93,74 @@ send_mail(
     fail_silently=False,
 )
 
+@swagger_auto_schema(
+    method='post',
+    request_body=openapi.Schema(
+        type=openapi.TYPE_OBJECT,
+        properties={
+            'email': openapi.Schema(type=openapi.TYPE_STRING, description='Email of the user to reset password'),
+        },
+        required=['email']
+    ),
+    responses={
+        200: openapi.Response(description="Password reset email sent."),
+        400: openapi.Response(description="Invalid email."),
+    }
+)
+@api_view(['POST'])
+def forgot_password(request):
+    email = request.data.get('email')
+    if not email:
+        return Response({"error": "Email is required."}, status=status.HTTP_400_BAD_REQUEST)
+
+    try:
+        user = User.objects.get(email=email)
+    except User.DoesNotExist:
+        return Response({"detail": "Please check your inbox and junk folder for the password reset email"}, status=status.HTTP_200_OK)
+
+    token = default_token_generator.make_token(user)
+    uid = urlsafe_base64_encode(force_bytes(user.pk))
+    reset_url = reverse('password-reset', kwargs={'uidb64': uid, 'token': token})
+    reset_link = f'http://{settings.SITE_DOMAIN}{reset_url}'
+
+    subject = "Fithub Password Reset Request"
+    message = f"To reset your password, click the following link: {reset_link}"
+    send_mail(subject, message, settings.DEFAULT_FROM_EMAIL, [email])
+
+    return Response({"detail": "If this email exists, a password reset link has been sent."}, status=status.HTTP_200_OK)
+
+@swagger_auto_schema(
+    method='post',
+    request_body=openapi.Schema(
+        type=openapi.TYPE_OBJECT,
+        properties={
+            'new_password': openapi.Schema(type=openapi.TYPE_STRING, description='New password for the user'),
+        },
+    ),
+    responses={
+        200: openapi.Response(description='Password has been reset successfully.'),
+        400: openapi.Response(description='Invalid token or password missing.'),
+    },
+)
+@api_view(['POST'])
+def password_reset(request, uidb64, token):
+    try:
+        uid = urlsafe_base64_decode(uidb64).decode()
+        user = User.objects.get(pk=uid)
+    except (User.DoesNotExist, ValueError, OverflowError):
+        return Response({"error": "Invalid token or user."}, status=status.HTTP_400_BAD_REQUEST)
+
+    if default_token_generator.check_token(user, token):
+        new_password = request.data.get("new_password")
+        if new_password:
+            user.password = make_password(new_password)
+            user.save()
+            return Response({"detail": "Password has been reset successfully."}, status=status.HTTP_200_OK)
+        return Response({"error": "New password is required."}, status=status.HTTP_400_BAD_REQUEST)
+    
+    return Response({"error": "Invalid token."}, status=status.HTTP_400_BAD_REQUEST)
+
+
 class login_view(APIView):
     @swagger_auto_schema(
         request_body=LoginSerializer(),  # Specify the serializer for login

--- a/backend/fithub/api_documentations/forgot password 6 digit code version.md
+++ b/backend/fithub/api_documentations/forgot password 6 digit code version.md
@@ -1,0 +1,89 @@
+
+### **Request Password Reset Code**
+
+**POST** `/api/request-password-reset-code/`
+
+-   **Description**: This endpoint allows a user to request a password reset. Upon successful request, a 6-digit code will be sent to the provided email address for verifying the password reset.
+    
+
+#### Request Body Example:
+
+    {
+      "email": "john.doe@example.com"
+    }
+
+#### Fields:
+
+-   `email` (string): The email address of the user who wants to reset the password.
+    
+
+#### Response:
+
+-   **Success**:
+    
+    -   Status: `200 OK`
+        
+    -   Response body
+    {
+          "detail": "Password reset code sent successfully."
+    }
+**Error**:
+
+-   Status: `400 Bad Request`
+    
+-   Possible Messages:
+
+	{
+    	  "email": ["This email address is not registered."]
+    }
+
+Status: `500 Internal Server Error` (if something goes wrong with email sending)
+
+    {
+      "detail": "There was an issue sending the email."
+    }
+### **Verify Reset Code**
+
+**POST** `/api/verify-reset-code/`
+
+-   **Description**: This endpoint verifies the 6-digit reset code sent to the user’s email. If the code matches the one sent, the user will be allowed to reset their password.
+    
+
+#### Request Body Example:
+
+    {
+      "email": "john.doe@example.com",
+      "reset_code": "123456"
+    }
+#### Fields:
+
+-   `email` (string): The email address of the user attempting to verify the reset code.
+    
+-   `reset_code` (string): The 6-digit code sent to the user's email address.
+    
+
+#### Response:
+
+-   **Success**:
+    
+    -   Status: `200 OK`
+        
+    -   Response body: 
+
+{
+  "detail": "Reset code verified successfully. You can now reset your password."
+}
+**Error**:
+
+-   Status: `400 Bad Request`
+    
+-   Possible Messages:
+
+    {
+      "reset_code": ["Invalid reset code."]
+    }
+
+    {
+      "email": ["Email address not registered."]
+    }
+

--- a/backend/fithub/api_documentations/forgot_password and password_reset.md
+++ b/backend/fithub/api_documentations/forgot_password and password_reset.md
@@ -1,0 +1,87 @@
+
+### **Forgot Password**
+
+**POST** `/api/forgot-password/`
+
+-   **Description**: This endpoint allows a user to initiate the password reset process. It sends a password reset email with a secure tokenized link to the user’s registered email address.
+    
+
+#### Request Body Example:
+
+    {
+      "email": "user@example.com"
+    }
+  
+  #### **Fields**:
+
+-   `email` (string): The user's registered email address.
+    
+
+#### Response:
+
+-   **Success**:
+    
+    -   Status: `200 OK`
+        
+    -   Response body:
+{
+  "detail": "Password reset email has been sent."
+}
+**Error**:
+
+-   Status: `400 Bad Request`
+
+    {
+      "email": ["This field is required."]
+    }
+-   Status: `404 Not Found`
+
+    {
+      "detail": "No user found with this email."
+    }
+
+### **Reset Password**
+
+**POST** `/api/reset-password/`
+
+-   **Description**: This endpoint allows users to reset their password using the token sent to their email from the forgot password request.
+    
+
+#### Request Body Example:
+
+    {
+      "token": "abc123xyz-token-string",
+      "new_password": "NewSecurePassword123"
+    }
+#### Fields:
+
+-   `token` (string): The token received via email to verify password reset request.
+    
+-   `new_password` (string): The new password the user wants to set.
+    
+
+#### Response:
+
+-   **Success**:
+    
+    -   Status: `200 OK`
+        
+    -   Response body:
+    {
+      "detail": "Password has been reset successfully."
+    }
+
+**Error**:
+
+-   Status: `400 Bad Request`
+
+    {
+      "token": ["This field is required."]
+    }
+Status: `401 Unauthorized`
+
+    {
+      "detail": "Invalid or expired token."
+    }
+
+

--- a/backend/fithub/fithub/settings.py
+++ b/backend/fithub/fithub/settings.py
@@ -164,3 +164,5 @@ DEFAULT_FROM_EMAIL = EMAIL_HOST_USER
 
 
 AUTH_USER_MODEL = 'api.RegisteredUser'
+
+SITE_DOMAIN = "http://localhost:8000" 

--- a/backend/fithub/misc/test.rest
+++ b/backend/fithub/misc/test.rest
@@ -2,13 +2,10 @@ POST http://127.0.0.1:8000/api/register/
 Content-Type: application/json
 
 {
-  "username": "dietitianjohn154",
-  "email": "dietitian.john154@example.com",
-  "password": "secureDietitianPassword123",
-  "usertype": "dietitian",
-  "dietitian": {
-    "certification_url": "https://example.com/certifications/john_certification"
-  }
+  "username": "ozgur2",
+  "email": "savascio@unhcr.com",
+  "password": "123",
+  "usertype": "user"
 }
 ###
 
@@ -17,9 +14,17 @@ Content-Type: application/json
 
 {
   "email": "savasciogluozgur@gmail.com",
-  "password": "123"
+  "password": "333"
 }
 ###
 
 POST http://127.0.0.1:8000/api/logout/
 Authorization: Token d2a5f9c71b45d88ed04b8ce9d2ceec2378b47c25
+
+
+###
+
+POST http://127.0.0.1:8000/api/forgot-password//
+{
+  "email": "savasciogluozgur@gmail.com",
+}

--- a/backend/fithub/misc/test.rest
+++ b/backend/fithub/misc/test.rest
@@ -14,7 +14,7 @@ Content-Type: application/json
 
 {
   "email": "savasciogluozgur@gmail.com",
-  "password": "333"
+  "password": "44404445"
 }
 ###
 


### PR DESCRIPTION
This PR introduces two alternative flows for password reset:

- Email Link – Sends a reset link to the user's email (standard flow).
- 6-Digit Code – Sends a numeric code for users to verify and reset their password via code entry. Both flows include complete API views, serializers, email integration, and Swagger documentation.