### PR TITLE
Prevent user from editing/deleting other users posts

### DIFF
--- a/mobile/lib/screens/community/post_detail_screen.dart
+++ b/mobile/lib/screens/community/post_detail_screen.dart
@@ -402,7 +402,7 @@ class _PostDetailScreenState extends State<PostDetailScreen> {
           },
         ),
         actions: [
-          if (post != null) ...[
+          if (post != null && _currentUserId != null && post!['author_id'] == _currentUserId) ...[
             IconButton(
               icon: const Icon(Icons.edit),
               onPressed: _navigateToEditScreen,


### PR DESCRIPTION
### 🔗 Related Issue [issue_link](https://github.com/bounswe/bounswe2025group6/issues/218)

---
### 📌 Changes made

- A quick fix that prevents users from editing/deleting other users' posts

---

### 📋 Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation in api_documentations (if appropriate)
- [x] My changes do not introduce new warnings or errors

---

### 💬 Any additional Notes, Requests

- 

---
