### PR TITLE
Implement "Ingredient Description Endpoint" by external API: WikiData

### DIFF
--- a/practice-app/backend/fithub/ingredients/views.py
+++ b/practice-app/backend/fithub/ingredients/views.py
@@ -330,7 +330,44 @@ class WikidataViewSet(viewsets.ViewSet):
         serializer = WikidataInfoSerializer(ingredients, many=True)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
+     # Retrieve DESCRIPTION ENDPOINT
+    @swagger_auto_schema(
+        operation_description="Retrieve the Wikidata description for a specific ingredient.",
+        tags=["IngredientWikidata"],
+        manual_parameters=[
+            openapi.Parameter(
+                'ingredient_id',
+                openapi.IN_QUERY,
+                description="The ID of the ingredient.",
+                type=openapi.TYPE_INTEGER,
+                required=True
+            )
+        ],
+        responses={
+            200: openapi.Response(description="Wikidata description retrieved successfully."),
+            404: openapi.Response(description="Ingredient or Wikidata info not found."),
+        }
+    )
+    @action(detail=False, methods=['get'], url_path='wikidata-description')
+    def get_wikidata_description(self, request):
+        ingredient_id = request.query_params.get('ingredient_id')
+        if not ingredient_id:
+            return Response({"error": "ingredient_id is required."}, status=status.HTTP_400_BAD_REQUEST)
+
+        try:
+            wikidata_info = WikidataInfo.objects.get(ingredient_id=ingredient_id)
+            return Response({"wikidata_description": wikidata_info.wikidata_description}, status=status.HTTP_200_OK)
+        except WikidataInfo.DoesNotExist:
+            return Response({"error": "Wikidata info not found for the given ingredient."}, status=status.HTTP_404_NOT_FOUND)
+
+
+
+
+
+
+
     #ADD OTHER ENDPOINTS
+    
     #allergens
     #description - Celil written that.
     #label
@@ -339,3 +376,19 @@ class WikidataViewSet(viewsets.ViewSet):
  
     #origin
     #category
+
+
+
+
+
+
+
+
+
+
+   
+
+
+
+
+


### PR DESCRIPTION
## 🚀 Pull Request Template

### 🔗 Related Issue Close #293 

---
### 📌 Changes made

Changes:
- Added description endpoint by external WikiData API.
- Added Swagger documentation accordingly.
---

### 📥 Implemented/Modified Endpoints
- GET /ingredients/wikidata/wikidata-description/

---

### 📋 Checklist


- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation in api_documentations (if appropriate)
- [X] My changes do not introduce new warnings or errors