### PR TITLE
Fetch recipe images from external api Wikidata. From GET wikidata image.

### DIFF
--- a/practice-app/frontend/src/components/recipe/RecipeCard.jsx
+++ b/practice-app/frontend/src/components/recipe/RecipeCard.jsx
@@ -1,25 +1,80 @@
 // src/components/recipe/RecipeCard.jsx
 
-import React from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Button from '../ui/Button';
-import { getRecipeById } from '../../services/recipeService';
+import { getRecipeById, getWikidataImage } from '../../services/recipeService';
 import '../../styles/RecipeCard.css';
 
 const RecipeCard = ({ recipe }) => {
   const navigate = useNavigate();
+  const [recipeImage, setRecipeImage] = useState(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isVisible, setIsVisible] = useState(false);
+  const cardRef = useRef(null);
+
+  // Lazy loading with IntersectionObserver
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true);
+          observer.disconnect();
+        }
+      },
+      { threshold: 0.1 }
+    );
+
+    if (cardRef.current) {
+      observer.observe(cardRef.current);
+    }
+
+    return () => {
+      if (cardRef.current) {
+        observer.disconnect();
+      }
+    };
+  }, []);
+
+  // Only load image when card becomes visible
+  useEffect(() => {
+    const loadImage = async () => {
+      if (!isVisible || isLoading || recipeImage) return;
+      
+      try {
+        setIsLoading(true);
+        if (recipe.name) {
+          const imageUrl = await getWikidataImage(recipe.name);
+          if (imageUrl) {
+            setRecipeImage(imageUrl);
+          }
+        }
+      } catch (error) {
+        console.error('Error fetching recipe image:', error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    loadImage();
+  }, [recipe.name, isVisible, isLoading, recipeImage]);
 
   const handleClick = () => {
     navigate(`/recipes/${recipe.id}`);
   };
-
-
   return (
-    <div className="recipe-card" onClick={handleClick}>
+    <div className="recipe-card" onClick={handleClick} ref={cardRef}>
       <div className='recipe-card-image' style={{
-				backgroundImage:
-					'url("https://images.unsplash.com/photo-1484723091739-30a097e8f929?q=80&w=1547&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D")'
-			}}></div>
+				backgroundImage: recipeImage 
+          ? `url("${recipeImage}")` 
+          : 'url("https://images.unsplash.com/photo-1484723091739-30a097e8f929?q=80&w=1547&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D")'
+			}}>
+        {isLoading && (
+          <div className="image-loader">
+            <div className="loader-spinner"></div>
+          </div>
+        )}
+      </div>
       <div className='recipe-card-content'>
         <h2>{recipe.name}</h2>
         <div className='recipe-card-content-info'>

--- a/practice-app/frontend/src/pages/recipes/RecipeDiscoveryPage.jsx
+++ b/practice-app/frontend/src/pages/recipes/RecipeDiscoveryPage.jsx
@@ -20,7 +20,6 @@ const RecipeDiscoveryPage = () => {
   useEffect(() => {
     document.title = "Recipe Discovery";
   }, []);
-
   useEffect(() => {
     const loadRecipes = async () => {
       try {
@@ -29,6 +28,15 @@ const RecipeDiscoveryPage = () => {
         setRecipes(response.results);
         setFilteredRecipes(response.results);
         setTotalPages(Math.ceil(response.total / 10));
+        
+        // Optional: Prefetch next page data after current page loads
+        if (currentPage < Math.ceil(response.total / 10)) {
+          setTimeout(() => {
+            fetchRecipes(currentPage + 1, 10).catch(err => 
+              console.log('Error prefetching next page:', err)
+            );
+          }, 2000);
+        }
       } catch (err) {
         setError(err.message);
       } finally {

--- a/practice-app/frontend/src/styles/RecipeCard.css
+++ b/practice-app/frontend/src/styles/RecipeCard.css
@@ -10,6 +10,35 @@
   background-position: center center;
   background-size: cover;
   background-repeat: no-repeat;
+  position: relative;
+}
+
+/* Image loader styling */
+.image-loader {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(255, 255, 255, 0.5);
+}
+
+.loader-spinner {
+  width: 50px;
+  height: 50px;
+  border: 5px solid rgba(0, 0, 0, 0.1);
+  border-top-color: #389f6c;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .recipe-card-content {
@@ -25,7 +54,6 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
-
 }
 
 .recipe-card-content::before {
@@ -38,7 +66,6 @@
   background: linear-gradient(0deg, #38a169, #2b6cb0) left bottom no-repeat;
 }
 
-
 .recipe-card-content::after {
   position: absolute;
   content: '';
@@ -49,7 +76,7 @@
   background: linear-gradient(to right, #38a169, #2b6cb0) left bottom no-repeat;
 }
 
-.recipe-card-content h2{
+.recipe-card-content h2 {
   padding: 0;
   margin: 0;
   margin-bottom: 10px;


### PR DESCRIPTION
## 🚀 Pull Request Template

### 🔗 #307 closes

---
### 📌 Changes made

- Wikidata fetch image functionality implemented to the frontend
- Recipe images shown on the both discovery page and detailed recipe page

---

### 📥 Used Endpoints
- GET /api/ingredients/wikidata/image

---

### 📋 Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation in api_documentations (if appropriate)
- [x] My changes do not introduce new warnings or errors

---

### 💬 Any additional Notes, Requests

- 

---
