### PR TITLE
FRONTEND: Add image upload functionality to recipe pages

### DIFF
--- a/practice-app/frontend/src/components/recipe/RecipeCard.jsx
+++ b/practice-app/frontend/src/components/recipe/RecipeCard.jsx
@@ -44,6 +44,14 @@ const RecipeCard = ({ recipe }) => {
       
       try {
         setIsLoading(true);
+        
+        // First check if recipe has an uploaded image
+        if (recipe.image_full_url) {
+          setRecipeImage(recipe.image_full_url);
+          return;
+        }
+        
+        // If no uploaded image, try to get from Wikidata
         if (recipe.name) {
           const imageUrl = await getWikidataImage(recipe.name);
           if (imageUrl) {
@@ -58,7 +66,7 @@ const RecipeCard = ({ recipe }) => {
     };
 
     loadImage();
-  }, [recipe.name, isVisible, isLoading, recipeImage]);
+  }, [recipe.name, recipe.image_full_url, isVisible, isLoading, recipeImage]);
   
   // Fetch creator's username
   useEffect(() => {

--- a/practice-app/frontend/src/pages/recipes/RecipeDetailPage.jsx
+++ b/practice-app/frontend/src/pages/recipes/RecipeDetailPage.jsx
@@ -56,15 +56,20 @@ const RecipeDetailPage = () => {
             setCreatorName(name);
           }
           
-          // Fetch image from Wikidata API
-          try {
-            const imageUrl = await getWikidataImage(recipeData.name);
-            if (imageUrl) {
-              setRecipeImage(imageUrl);
+          // First check if recipe has an uploaded image
+          if (recipeData.image_full_url) {
+            setRecipeImage(recipeData.image_full_url);
+          } else {
+            // If no uploaded image, try to get from Wikidata API
+            try {
+              const imageUrl = await getWikidataImage(recipeData.name);
+              if (imageUrl) {
+                setRecipeImage(imageUrl);
+              }
+            } catch (imageError) {
+              console.error('Failed to load recipe image:', imageError);
+              // Don't set error state, just continue without image
             }
-          } catch (imageError) {
-            console.error('Failed to load recipe image:', imageError);
-            // Don't set error state, just continue without image
           }
         } else {
           setError('Recipe not found');

--- a/practice-app/frontend/src/pages/recipes/UploadRecipePage.jsx
+++ b/practice-app/frontend/src/pages/recipes/UploadRecipePage.jsx
@@ -20,7 +20,8 @@ const UploadRecipePage = () => {
 
   const [recipeData, setRecipeData] = useState({
     name: "",
-    image_url: "",
+    image: null, // File object for image upload
+    imagePreview: null, // URL for image preview
     cooking_time: "",
     prep_time: "",
     meal_type: "",
@@ -100,6 +101,47 @@ const UploadRecipePage = () => {
     setRecipeData((prev) => ({ ...prev, [name]: value }));
   };
 
+  // Handle image file selection
+  const handleImageChange = (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+
+    // Validate file type
+    if (!file.type.match('image.*')) {
+      toast.error('Please select an image file (PNG or JPG)');
+      return;
+    }
+
+    // Validate file size (max 5MB)
+    if (file.size > 5 * 1024 * 1024) {
+      toast.error('Image must be less than 5MB');
+      return;
+    }
+
+    // Create preview URL
+    const previewUrl = URL.createObjectURL(file);
+
+    setRecipeData((prev) => ({
+      ...prev,
+      image: file,
+      imagePreview: previewUrl,
+      image_url: '' // Clear URL if file is selected
+    }));
+  };
+
+  // Handle image removal
+  const handleImageRemove = () => {
+    if (recipeData.imagePreview) {
+      URL.revokeObjectURL(recipeData.imagePreview);
+    }
+    
+    setRecipeData((prev) => ({
+      ...prev,
+      image: null,
+      imagePreview: null
+    }));
+  };
+
   const handleAddIngredient = (ingredient) => {
     if (!ingredient || !ingredient.id) return;
 
@@ -165,13 +207,40 @@ const UploadRecipePage = () => {
         </div>
 
         <div className="form-group">
-          <label htmlFor="image_url">Image URL</label>
-          <input
-            id="image_url"
-            name="image_url"
-            value={recipeData.image_url}
-            onChange={handleChange}
-          />
+          <label htmlFor="image">Recipe Image</label>
+          <div className="image-upload-container">
+            {recipeData.imagePreview ? (
+              <div className="image-preview">
+                <img 
+                  src={recipeData.imagePreview} 
+                  alt="Recipe preview" 
+                  className="preview-image"
+                />
+                <button 
+                  type="button" 
+                  onClick={handleImageRemove}
+                  className="remove-image-btn"
+                  title="Remove Image"
+                >
+                </button>
+              </div>
+            ) : (
+              <div className="image-upload-area">
+                <input
+                  id="image"
+                  name="image"
+                  type="file"
+                  accept="image/*"
+                  onChange={handleImageChange}
+                  className="image-input"
+                />
+                <label htmlFor="image" className="image-upload-label">
+                  <span>📷</span>
+                  <span>Click to upload image (PNG/JPG, max 5MB)</span>
+                </label>
+              </div>
+            )}
+          </div>
         </div>
 
         <div className="form-group">

--- a/practice-app/frontend/src/styles/UploadRecipePage.scss
+++ b/practice-app/frontend/src/styles/UploadRecipePage.scss
@@ -337,9 +337,92 @@
     margin-left: 10px;
     width: 300px; // Adjust based on label width
   }
-  input[name="image_url"] {
+  // Image upload styles
+  .image-upload-container {
     margin-left: 10px;
-    width: calc(100% - 120px); // Adjust based on label width
+    
+    .image-upload-area {
+      position: relative;
+      border: 2px dashed #ccc;
+      border-radius: 8px;
+      padding: 2rem;
+      text-align: center;
+      background: rgba(255, 255, 255, 0.9);
+      transition: all 0.3s ease;
+      
+      &:hover {
+        border-color: #3b82f6;
+        background: rgba(59, 130, 246, 0.05);
+      }
+      
+      .image-input {
+        position: absolute;
+        opacity: 0;
+        width: 100%;
+        height: 100%;
+        cursor: pointer;
+      }
+      
+      .image-upload-label {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 0.5rem;
+        cursor: pointer;
+        color: #666;
+        
+        span:first-child {
+          font-size: 2rem;
+        }
+        
+        span:last-child {
+          font-size: 0.9rem;
+        }
+      }
+    }
+    
+    .image-preview {
+      position: relative;
+      display: inline-block;
+      
+      .preview-image {
+        max-width: 200px;
+        max-height: 200px;
+        border-radius: 8px;
+        object-fit: cover;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+      }
+      
+      .remove-image-btn {
+        position: absolute;
+        top: -8px;
+        right: -8px;
+        background: #ff4444;
+        color: white;
+        border: none;
+        border-radius: 50%;
+        width: 24px;
+        height: 24px;
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        transition: all 0.2s ease;
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+        
+        &:hover {
+          background: #cc0000;
+          transform: scale(1.1);
+        }
+        
+        &::before {
+          content: "×";
+          font-size: 16px;
+          font-weight: bold;
+          line-height: 1;
+        }
+      }
+    }
   }
 
   input[name="cooking_time"],


### PR DESCRIPTION
### 🔗 [Related Issue 456](https://github.com/bounswe/bounswe2025group6/issues/456)

---
### 📌 Changes made

- Updated recipeService.js to use FormData for image uploads instead of JSON
- Added image upload UI to UploadRecipePage.jsx with file selection and preview
- Added image upload UI to RecipeEditPage.jsx with existing image display
- Implemented image validation (PNG/JPG, max 5MB) with user feedback
- Updated RecipeCard.jsx to prioritize uploaded images over Wikidata images
- Updated RecipeDetailPage.jsx to display uploaded images
- Added CSS styles for image upload components with hover effects
- Removed unused image_url field from state management
- Added simple X button for image removal

---

### 📥 Implemented Endpoints
- POST /recipes/ (updated to support multipart/form-data)
- PUT /recipes/{id}/ (updated to support multipart/form-data)

---

### 📋 Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation in api_documentations (if appropriate)
- [x] My changes do not introduce new warnings or errors

---

### 💬 Any additional Notes, Requests

- Backend already supports image upload with Cloudinary integration
- Image upload uses multipart/form-data format as required by backend
- Fallback system: uploaded images take priority over Wikidata images
- Simple and clean UI with drag-and-drop style upload area
- Image preview shows immediately after selection
- Validation prevents invalid file types and oversized files

---