### PR TITLE
FRONTEND: Cmpe352 Texts Converted to Cmpe451

### DIFF
--- a/practice-app/frontend/src/layouts/MainLayout.jsx
+++ b/practice-app/frontend/src/layouts/MainLayout.jsx
@@ -132,7 +132,7 @@ const MainLayout = () => {
           <p>© {new Date().getFullYear()} FitHub </p>
 
           <div className="layout-footer-links">
-            <p>Cmpe352 Group 6</p>
+            <p>Cmpe451 Group 6</p>
           </div>
         </div>
       </footer>

--- a/practice-app/frontend/src/locales/en.json
+++ b/practice-app/frontend/src/locales/en.json
@@ -46,6 +46,7 @@
   "recipeName": "Recipe Name",
   "currencyPreference": "Currency Preference",
   "datePreference": "Date Preference",
+  "failedToUpdateLanguagePreference": "Failed To Update Language Preference",
   "savedRecipes": "Saved Recipes",
   "Ingredients": "Ingredients",
   "ingredients": "Ingredients",

--- a/practice-app/frontend/src/locales/tr.json
+++ b/practice-app/frontend/src/locales/tr.json
@@ -46,6 +46,7 @@
   "recipeName": "Tarif İsmi",
   "currencyPreference": "Birim Tercihi",
   "datePreference": "Tarih Biçimi",
+  "failedToUpdateLanguagePreference": "Dil seçeneği yüklenirken hata oluştu",
   "savedRecipes": "Kaydedilen Tarifler",
   "Ingredients": "İçindekiler",
   "ingredients": "Malzemeler",


### PR DESCRIPTION
## 🚀 Pull Request Template

### 🔗 Related Issue 
Closes [522](https://github.com/bounswe/bounswe2025group6/issues/522)

---
### 📌 Changes made

- Cmpe352 texts converted to Cmpe451 in code files.
- Translating bug in 'MainLayout.jsx' is fixed.

---
