### PR TITLE
FRONTEND: Add question&answer to report type

### DIFF
--- a/practice-app/frontend/src/components/report/ReportButton.jsx
+++ b/practice-app/frontend/src/components/report/ReportButton.jsx
@@ -5,10 +5,14 @@ import './ReportButton.css';
 import { useAuth } from '../../contexts/AuthContext';
 import { useToast } from '../ui/Toast';
 
-const ReportButton = ({ targetType, targetId }) => {
+const ReportButton = ({ targetType, targetId, contentType, objectId }) => {
   const { currentUser } = useAuth();
   const toast = useToast();
   const [open, setOpen] = useState(false);
+
+  // Support both targetType/targetId and contentType/objectId props
+  const finalTargetType = targetType || contentType;
+  const finalTargetId = targetId || objectId;
 
   const handleOpen = () => {
     if (!currentUser) {
@@ -36,8 +40,8 @@ const ReportButton = ({ targetType, targetId }) => {
       <ReportModal
         isOpen={open}
         onClose={() => setOpen(false)}
-        targetType={targetType}
-        targetId={targetId}
+        targetType={finalTargetType}
+        targetId={finalTargetId}
         onSubmitted={() => setOpen(false)}
       />
       

--- a/practice-app/frontend/src/components/report/ReportModal.jsx
+++ b/practice-app/frontend/src/components/report/ReportModal.jsx
@@ -44,7 +44,9 @@ const ReportModal = ({ isOpen, onClose, targetType, targetId, onSubmitted }) => 
       const contentTypeMap = {
         'comment': 'postcomment',
         'post': 'post',
-        'recipe': 'recipe'
+        'recipe': 'recipe',
+        'question': 'question',
+        'answer': 'answer'
       };
       
       await reportService.createReport({


### PR DESCRIPTION
### 🔗 Related Issue
Closes #713 

---
### 📌 Changes made

- Add question and answer to ReportModal contentTypeMap
- Support both targetType/targetId and contentType/objectId props in ReportButton

---
### 📥 Implemented Endpoints
N/A - Frontend only

---
### 📋 Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation in api_documentations (if appropriate)
- [x] My changes do not introduce new warnings or errors

---
### 💬 Any additional Notes, Requests

- Enables reporting for Q&A questions and answers
- Backend already supports question/answer report types